### PR TITLE
Add option to automatically add LDAP users to a group

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     ldap_enabled: "Is LDAP plugin enabled?"
     ldap_user_create_mode: "User create mode: auto, list or none"
     ldap_lookup_users_by: "Attribute to lookup users by: email or username"
+    ldap_add_to_groups: "Automatically add LDAP authenticated users to these groups"
     ldap_hostname: "Hostname of LDAP server"
     ldap_port: "Connection port to LDAP server"
     ldap_method: "Connection method: ssl, tls or plain"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,8 @@ plugins:
     default: 'auto'
   ldap_lookup_users_by:
     default: 'email'
+  ldap_add_to_groups:
+    default: ''
   ldap_hostname:
     default: 'adfs.example.com'
   ldap_port:

--- a/plugin.rb
+++ b/plugin.rb
@@ -60,6 +60,9 @@ class LDAPAuthenticator < ::Auth::Authenticator
         match[:name] = match[:name] || auth_info[:name]
         return LDAPUser.new(match).auth_result
       when 'auto'
+        unless SiteSetting.ldap_add_to_groups.empty?
+          auth_info[:groups] = SiteSetting.ldap_add_to_groups.present
+        end
         return LDAPUser.new(auth_info).auth_result
       else
         return fail_auth('Invalid option for ldap_user_create_mode setting.')


### PR DESCRIPTION
This should add the ability to add users to groups automatically when they authenticate via LDAP.

It's a really simple patch (almost too simple...), so may need testing further than my cursory efforts.