### PR TITLE
Make LDAP password field secret

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,5 +19,6 @@ plugins:
     default: ''
   ldap_password:
     default: ''
+    secret: true
   ldap_filter:
     default: ''


### PR DESCRIPTION
I just realized when installing the plugin that the password field wasn't marked as secret, thus revealing it in the admin panel :open_mouth: 

Fortunately, this is a really easy fix!

(Thanks for the plugin, it works perfectly)