### PR TITLE
Ldap add to groups

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     ldap_enabled: "Is LDAP plugin enabled?"
     ldap_user_create_mode: "User create mode: auto, list or none"
     ldap_lookup_users_by: "Attribute to lookup users by: email or username"
+    ldap_add_to_groups: "Automatically add LDAP authenticated users to this group"
     ldap_hostname: "Hostname of LDAP server"
     ldap_port: "Connection port to LDAP server"
     ldap_method: "Connection method: ssl, tls or plain"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,8 @@ plugins:
     default: 'auto'
   ldap_lookup_users_by:
     default: 'email'
+  ldap_add_to_groups:
+    default: ''
   ldap_hostname:
     default: 'adfs.example.com'
   ldap_port:

--- a/plugin.rb
+++ b/plugin.rb
@@ -60,6 +60,9 @@ class LDAPAuthenticator < ::Auth::Authenticator
         match[:name] = match[:name] || auth_info[:name]
         return LDAPUser.new(match).auth_result
       when 'auto'
+        unless SiteSetting.ldap_add_to_groups.empty?
+          auth_info[:groups] = SiteSettings.ldap_add_to_groups.present
+        end
         return LDAPUser.new(auth_info).auth_result
       else
         return fail_auth('Invalid option for ldap_user_create_mode setting.')


### PR DESCRIPTION
Option to add all users who authenticate via LDAP to be assigned a specific group in discourse.

( minor changes to original b0b9ac8c636105dea77fcf4067dc2de4ddd21849 )