### PR TITLE
Update omit_username -> override_username following core changes

### DIFF
--- a/lib/ldap_user.rb
+++ b/lib/ldap_user.rb
@@ -15,7 +15,12 @@ class LDAPUser
     result.username = @username
     result.email = @email
     result.user = @user
-    result.omit_username = true
+    if result.respond_to? :overrides_username
+      result.overrides_username = true
+    else
+      # TODO: Remove once Discourse 2.8 stable is released
+      result.omit_username = true
+    end
     result.email_valid = true
     return result
   end

--- a/spec/lib/auth.rb
+++ b/spec/lib/auth.rb
@@ -17,7 +17,7 @@ module Auth
                   :email_valid, :extra_data, :awaiting_activation,
                   :awaiting_approval, :authenticated, :authenticator_name,
                   :requires_invite, :not_allowed_from_ip_address,
-                  :admin_not_allowed_from_ip_address, :omit_username
+                  :admin_not_allowed_from_ip_address, :overrides_username
 
     attr_accessor :failed,
                   :failed_reason


### PR DESCRIPTION
This commit maintains backwards compatibility with older Discourse changes