### PR TITLE
Only override username on initial signup

### DIFF
--- a/lib/ldap_user.rb
+++ b/lib/ldap_user.rb
@@ -16,7 +16,7 @@ class LDAPUser
     result.email = @email
     result.user = @user
     if result.respond_to? :overrides_username
-      result.overrides_username = true
+      result.overrides_username = true if !account_exists?
     else
       # TODO: Remove once Discourse 2.8 stable is released
       result.omit_username = true

--- a/spec/ldap_authenticator_spec.rb
+++ b/spec/ldap_authenticator_spec.rb
@@ -95,4 +95,24 @@ describe LDAPAuthenticator do
       expect(result.user).to eq(user)
     end
   end
+
+  describe "overrides_username behaviour" do
+    it "overrides username during initial signup" do
+      result = authenticator.after_authenticate(auth_hash)
+      expect(result.username).to eq(auth_hash.info[:nickname])
+      expect(result.failed?).to eq(false)
+      expect(result.user).to be_nil
+      expect(result.overrides_username).to eq(true)
+    end
+
+    it "does not override username on future logins" do
+      SiteSetting.ldap_lookup_users_by = 'username'
+      user = Fabricate(:user, username: "tester")
+      result = authenticator.after_authenticate(auth_hash)
+      expect(result.username).to eq(auth_hash.info[:nickname])
+      expect(result.failed?).to eq(false)
+      expect(result.user).to eq(user)
+      expect(result.overrides_username).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
073cb00d switched the plugin from the deprecated `omit_username` to the new `overrides_username` flag. However, there is a slight behavior difference in these flags. `omit_username` only applied during initial signup, while `overrides_username` applies to all logins.

This commit updates the logic so that overrides_username is only used during initial signup, thereby reversing the behavior change introduced by 073cb00d.

Context at https://meta.discourse.org/t/213908