### PR TITLE
Use translations

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,8 @@
+en:
+  js:
+    login:
+      ldap:
+        name: "LDAP"
+        title: "with LDAP"
+        sr_title: "Login with LDAP"
+        message: "Authenticating with LDAP"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1,0 +1,6 @@
+es:
+  js:
+    login:
+      ldap:
+        name: "LDAP"
+        title: "con LDAP"

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -1,0 +1,6 @@
+it:
+  js:
+    login:
+      ldap:
+        name: "LDAP"
+        title: "con LDAP"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -1,0 +1,6 @@
+pt_BR:
+  js:
+    login:
+      ldap:
+        name: "LDAP"
+        title: "com a LDAP"

--- a/plugin.rb
+++ b/plugin.rb
@@ -78,8 +78,7 @@ class ::LDAPAuthenticator < ::Auth::Authenticator
   end
 end
 
-auth_provider title: 'with LDAP',
-  authenticator: LDAPAuthenticator.new
+auth_provider authenticator: LDAPAuthenticator.new
 
 register_css <<CSS
   .btn {


### PR DESCRIPTION
Rely on translations to admins can configure the button text from Admin - Customize - Text
See https://meta.discourse.org/t/customizing-text-in-auth-plugin-outside-of-after-initialize/217638
