### PR TITLE
[enh] Allow to define another attribute as primary mail source

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,3 +11,4 @@ en:
     ldap_bind_dn: "LDAP bind dn (needed if LDAP server does not allow anonymous binding)"
     ldap_password:  "LDAP bind password (needed if LDAP server does not allow anonymous binding)"
     ldap_filter:  "LDAP filter (for group based authentication)"
+    ldap_email:  "Mail attribute to bind in priority to discourse primary mail"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,5 @@ plugins:
     secret: true
   ldap_filter:
     default: ''
+  ldap_email:
+    default: 'email'

--- a/lib/ldap_user.rb
+++ b/lib/ldap_user.rb
@@ -7,6 +7,14 @@ class LDAPUser
     @email = auth_info[:email]
     @username = auth_info[:nickname]
     @user = SiteSetting.ldap_lookup_users_by == 'username' ? User.find_by_username(@username) : User.find_by_email(@email)
+    primary_email = @user.user_emails.find_by(email: @user.email)
+    if primary_email.present?
+      primary_email.update!(email: @email)
+    else
+      @user.user_emails.update_all(primary: false)
+      @user.user_emails.create!(email: @email, primary: true)
+    end
+    @user.reload
     create_user_groups(auth_info[:groups]) unless self.account_exists?
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -26,6 +26,16 @@ class ::LDAPAuthenticator < ::Auth::Authenticator
   end
 
   def after_authenticate(auth_options)
+    if SiteSetting.ldap_email != 'email'
+      if not auth_options.extra[:raw_info][SiteSetting.ldap_email].blank?
+        emails = Array(auth_options.extra[:raw_info][SiteSetting.ldap_email])
+          .select { |email| email.match?(/\A[^@\s]+@[^@\s]+\z/) }
+        if not emails.empty?
+          auth_options.info[:email] = emails.first()
+        end
+      end
+    end
+
     auth_result(auth_options.info)
   end
 


### PR DESCRIPTION
## Problem

In yunohost LDAP database, sometimes we do not want to use the first mail attribute as discourse primary mail. 

## Solution
Allow to configure which mail attribute use in priority for discourse primary mail (and fallback on mail if empty).

This PR update the primary mail with LDAP db at each authentication (in the current base code, it was only set at creation, and after user could edit manually the primary mail).

Note: it's a POC, we think more thinking and discussion are needed to create a good use case.

This PR extends https://github.com/jonmbake/discourse-ldap-auth/pull/82

## Status
Tested manually